### PR TITLE
Difficulty Selection Fix

### DIFF
--- a/doom64/m_main.c
+++ b/doom64/m_main.c
@@ -48,7 +48,7 @@ char *ControlText[] =   //8007517C
 #define M_TXT16 "Bring it on!"
 #define M_TXT17 "I own Doom!"
 #define M_TXT18 "Watch me die!"
-#define M_TXT19 "Nightmare"
+#define M_TXT19 "Nightmare!"
 #define M_TXT20 "Yes"
 #define M_TXT21 "No"
 #define M_TXT22 "Features"
@@ -1033,7 +1033,8 @@ int M_MenuTicker(void) // 80007E0C
                 case 16: // Bring it on!
                 case 17: // I own Doom!
                 case 18: // Watch me die!
-                //case 19: // Nightmare
+				case 19: // Nightmare!
+                
                     if (truebuttons)
                     {
                         S_StartSound(NULL, sfx_pistol);


### PR DESCRIPTION
Here are the suggested changes...

Line 51 adds the "!" to the nightmare difficulty setting, suggested to be more consistent with the others.
Line 1036 enables case 19, which allows the normal controller buttons to access the "Nightmare!" difficulty. No longer requires the start button only.