### PR TITLE
Fix action special 123

### DIFF
--- a/doom64/p_spec.c
+++ b/doom64/p_spec.c
@@ -1031,8 +1031,8 @@ boolean P_UseSpecialLine (line_t *line, mobj_t *thing) // 800204BC
         case 122:		/* PlatDownWaitUpStay */
 			ok = EV_DoPlat(line, upWaitDownStay, 0);
 			break;
-        case 123:		/* Blazing PlatDownWaitUpStay */
-			ok = EV_DoPlat(line, blazeDWUS, 0);
+        case 123:		/* Blazing PlatUpWaitDownStay */
+			ok = EV_DoPlat(line, blazeUWDS, 0);
 			break;
         case 124:		/* Secret EXIT */
 			P_SecretExitLevel(line->tag);//(G_SecretExitLevel)


### PR DESCRIPTION
Special #123 should be PlatUpWaitDownStay, but instead was a duplicate of 121 (PlatDownWaitUpStay).

Can you please check if this was an oversight during the reverse engineering, or was it like this in the original game?

This was causing a platform in Lost Levels map#34 to never raise in the N64 .