### PR TITLE
Fix reinitializing sector number on Stairs_Build special

### DIFF
--- a/doom64/p_floor.c
+++ b/doom64/p_floor.c
@@ -430,6 +430,7 @@ int EV_BuildStairs(line_t *line, stair_e type) // 80013DB0
 				break;
 			}
 		} while(ok);
+		secnum = -1;
 	}
 	return rtn;
 }


### PR DESCRIPTION
This fixes the stairs on Even Simpler not raising. The special is missing a reinitialization of the iterated sector index. This also matches how it was implemented on D64EX.

Opening this PR so you can check if this was omitted by mistake during the reverse engineering.